### PR TITLE
Fix: Bypass SSL verification for football-data.org

### DIFF
--- a/sports_prediction_ai/src/data_collection.py
+++ b/sports_prediction_ai/src/data_collection.py
@@ -1,6 +1,7 @@
 # src/data_collection.py
 import os
 import requests
+import warnings
 from datetime import datetime
 
 # It's good practice to load the API key from an environment variable
@@ -36,7 +37,11 @@ def get_matches_for_date(date_str: str, api_key: str = FOOTBALL_DATA_API_KEY):
     api_url = f"{FOOTBALL_DATA_BASE_URL}matches?dateFrom={date_str}&dateTo={date_str}"
 
     try:
-        response = requests.get(api_url, headers=headers)
+        warnings.warn(
+            "Bypassing SSL certificate verification for api.football-data.org. This is a potential security risk. Consider installing the appropriate SSL certificates for a more secure connection.",
+            UserWarning
+        )
+        response = requests.get(api_url, headers=headers, verify=False)
         response.raise_for_status()  # Raises an HTTPError for bad responses (4XX or 5XX)
         data = response.json()
         return data.get("matches", [])


### PR DESCRIPTION
I modified the `get_matches_for_date` function in `src/data_collection.py` to include `verify=False` in the `requests.get` call to `api.football-data.org`. This change resolves the `SSLCertVerificationError` encountered on some Windows environments where the local issuer certificate for the API's SSL certificate is not found.

I added a `UserWarning` to inform you that SSL verification is being bypassed for this specific API endpoint and that this carries a potential security risk. I recommend installing the appropriate SSL certificates for a more secure connection.

The pipeline now successfully attempts to fetch data from the API without SSL errors.